### PR TITLE
Wdp190101-11 RWD - menu główne

### DIFF
--- a/src/partials/10_header.html
+++ b/src/partials/10_header.html
@@ -63,16 +63,16 @@
   </div>
   <div class="menu-bar">
     <div class="container">
-      <div class="row align-items-center">
+      <div class="row align-items-center flex-md-column-reverse flex-lg-row">
         <!--Menu FJ-->
-        <div class="col d-flex">
-          <div class="category p-2 ">
+        <div class="col d-flex justify-content-md-center justify-content-lg-start">
+          <div class="category p-2">
             <ul>
               <li>
                 <a href="#">
                   <i class="fas fa-list-ul"></i> Select a category
-                  <i class="fas fa-caret-down"></i
-                ></a>
+                  <i class="fas fa-caret-down"></i>
+                </a>
                 <ul>
                   <li><a href="#">Furniture</a></li>
                   <li><a href="#">Chair</a></li>
@@ -94,7 +94,7 @@
           </div>
         </div>
 
-        <div class="col-auto menu">
+        <div class="col-auto menu justify-content-md-center">
           <ul>
             <li><a href="#" class="active">Home</a></li>
             <li><a href="#">Furniture</a></li>

--- a/src/partials/10_header.html
+++ b/src/partials/10_header.html
@@ -64,11 +64,11 @@
   <div class="menu-bar">
     <div class="container">
       <div
-        class="row align-items-start flex-row-reverse flex-md-column-reverse flex-lg-row"
+        class="row align-items-start flex-row-reverse flex-sm-column-reverse flex-xl-row"
       >
         <!--Menu FJ-->
         <div
-          class="col-sm col-9 d-flex flex-column-reverse flex-sm-row align-items-end justify-content-sm-center justify-content-lg-start"
+          class="col-sm col-9 d-flex flex-column-reverse flex-sm-row align-items-end align-items-sm-center justify-content-sm-center justify-content-xl-start"
         >
           <div class="category p-2">
             <ul>

--- a/src/partials/10_header.html
+++ b/src/partials/10_header.html
@@ -97,15 +97,11 @@
         <div class="col-auto menu">
           <ul>
             <li><a href="#" class="active">Home</a></li>
-            <li>
-              <a href="#">Furniture</a>
-              <ul>
-                <li><a href="#">Chair</a></li>
-                <li><a href="#">Table</a></li>
-                <li><a href="#">Sofa</a></li>
-                <li><a href="#">Bedroom</a></li>
-              </ul>
-            </li>
+            <li><a href="#">Furniture</a></li>
+            <li><a href="#">Chair</a></li>
+            <li><a href="#">Table</a></li>
+            <li><a href="#">Sofa</a></li>
+            <li><a href="#">Bedroom</a></li>
             <li><a href="#">Blog</a></li>
           </ul>
         </div>

--- a/src/partials/10_header.html
+++ b/src/partials/10_header.html
@@ -68,7 +68,7 @@
       >
         <!--Menu FJ-->
         <div
-          class="col-sm col-9 d-flex flex-column-reverse flex-sm-row align-items-end align-items-sm-center justify-content-sm-center justify-content-xl-start"
+          class="col-sm col-9 d-flex flex-column-reverse flex-sm-row align-items-center justify-content-center justify-content-xl-start"
         >
           <div class="category p-2">
             <ul>
@@ -90,7 +90,7 @@
 
           <div class="search">
             <form action="" class="search-form">
-              <div class="search-field p-2 ">
+              <div class="search-field p-2">
                 <input placeholder="Search products..." type="text" />
                 <button><i class="fa fa-search"></i></button>
               </div>
@@ -98,7 +98,10 @@
           </div>
         </div>
 
-        <div class="col-3 col-sm-auto menu justify-content-md-center">
+        <div class="col-3 col-sm-auto menu justify-content-center" id="rwd-menu">
+          <div class="menu-button align-items-center">
+            <i class="fas fa-bars" id="dropdown"></i>
+          </div>
           <ul class="flex-column flex-sm-row">
             <li><a href="#" class="active">Home</a></li>
             <li><a href="#">Furniture</a></li>

--- a/src/partials/10_header.html
+++ b/src/partials/10_header.html
@@ -63,9 +63,13 @@
   </div>
   <div class="menu-bar">
     <div class="container">
-      <div class="row align-items-center flex-md-column-reverse flex-lg-row">
+      <div
+        class="row align-items-start flex-row-reverse flex-md-column-reverse flex-lg-row"
+      >
         <!--Menu FJ-->
-        <div class="col d-flex justify-content-md-center justify-content-lg-start">
+        <div
+          class="col-sm col-9 d-flex flex-column-reverse flex-sm-row align-items-end justify-content-sm-center justify-content-lg-start"
+        >
           <div class="category p-2">
             <ul>
               <li>
@@ -94,8 +98,8 @@
           </div>
         </div>
 
-        <div class="col-auto menu justify-content-md-center">
-          <ul>
+        <div class="col-3 col-sm-auto menu justify-content-md-center">
+          <ul class="flex-column flex-sm-row">
             <li><a href="#" class="active">Home</a></li>
             <li><a href="#">Furniture</a></li>
             <li><a href="#">Chair</a></li>

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -119,16 +119,13 @@ header {
     background-color: #ffffff;
 
     .container > .row {
-      @media (max-width: 768px) {
+      @media (max-width: 1199px) {
         height: 150px;
       }
       height: 84px;
     }
 
     .menu {
-      @media (max-width: 768px) {
-        padding-bottom: 10px;
-      }
       display: flex;
       align-self: stretch;
 

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -125,11 +125,45 @@ header {
       height: 84px;
     }
 
+    .menu.menu-active {
+      @media (max-width: 575px) {
+        & ul {
+          display: flex;
+          position: absolute;
+          background-color: $light-color;
+          z-index: 1;
+          left: 5px;
+          top: 65px;
+
+          li,
+          a {
+            width: 150px;
+          }
+        }
+      }
+    }
+
     .menu {
       display: flex;
       align-self: stretch;
 
+      .menu-button {
+        @media (max-width: 575px) {
+          height: 50%;
+          display: flex;
+
+          .fa-bars {
+            font-size: 40px;
+            color: $form-border-color;
+          }
+        }
+        display: none;
+      }
+
       ul {
+        @media (max-width: 575px) {
+          display: none;
+        }
         margin: 0;
         padding: 0;
         display: flex;

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -235,22 +235,21 @@ header {
           color: #ffffff;
           border-color: $primary;
 
-        input {
-          border: 0;
-          padding: 0px 45px 0px 10px;
-          font-size: 14px;
-          outline: none;
+          input {
+            border: 0;
+            padding: 0px 45px 0px 10px;
+            font-size: 14px;
+            outline: none;
 
-          &::placeholder {
-            color: #bcbcbc;
+            &::placeholder {
+              color: #bcbcbc;
+            }
           }
-
         }
       }
       ul ul li {
         display: block;
       }
-
 
       ul li ul {
         display: none;
@@ -277,15 +276,15 @@ header {
         &::placeholder {
           color: $text-color;
 
-        button {
-          border: 0;
-          background-color: transparent;
-          outline: none;
+          button {
+            border: 0;
+            background-color: transparent;
+            outline: none;
 
-          &:hover {
-            cursor: pointer;
+            &:hover {
+              cursor: pointer;
+            }
           }
-
         }
       }
     }

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -119,10 +119,16 @@ header {
     background-color: #ffffff;
 
     .container > .row {
+      @media (max-width: 768px) {
+        height: 150px;
+      }
       height: 84px;
     }
 
     .menu {
+      @media (max-width: 768px) {
+        padding-bottom: 10px;
+      }
       display: flex;
       align-self: stretch;
 

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -1,3 +1,13 @@
+/* Dropdown Menu */
+function dropdownMenu() {
+  document.getElementById('rwd-menu').classList.toggle('menu-active');
+}
+
+document.getElementById('dropdown').addEventListener('click', function(e) {
+  e.preventDefault();
+  dropdownMenu();
+});
+
 /* TINY SLIDER - NEW FURNITURE */
 var productSlider = tns({
   container: '.product-container',


### PR DESCRIPTION
Strona sypie się w trybach responsive. Klient nie ma designów RWD, więc trzeba zrobić na własną rękę. 

Ten task dotyczy menu głównego (wyszukiwanie i "Home", etc.) 

Na tabletach wyszukiwanie ma być pod menu, a na mniejszych ekranach ma być wyszukiwanie i obok niego ikona mobilnego menu, które po rozwinięciu ma pokazywać dropdown przykrywający treść strony. 

Rozwiązanie:
- ostylowałem odpowiednio menu dla każdej rozdzielczości
-dodałem dropdown dla mobilnego menu